### PR TITLE
Fix bug where receiver stops registering for messages

### DIFF
--- a/codegen/generator/browser/templates/receive_component.tsx.j2
+++ b/codegen/generator/browser/templates/receive_component.tsx.j2
@@ -66,14 +66,18 @@ export default abstract class S{{ state }}<ComponentState = {}> extends React.Co
     switch (parsedMessage.label) {
       {% for action in state.actions -%}
       case Labels.{{ action.label }}: {
-        const thunk = () =>
-          {%- if endpoint.efsm.is_send_state(action.succ) -%}
-          SendState.S{{ action.succ }};
-          {%- elif endpoint.efsm.is_receive_state(action.succ) -%}
-          ReceiveState.S{{ action.succ }};
-          {%- else -%}
-          TerminalState.S{{ action.succ }};
+        const thunk = () => {{ '{' }}
+          {%- if action.succ.id == state.id %}
+          this.props.register(Roles.Peers.{{ state.first_role }}, this.handle.bind(this));
           {%- endif %}
+          return {% if endpoint.efsm.is_send_state(action.succ) -%}
+          SendState
+          {%- elif endpoint.efsm.is_receive_state(action.succ) -%}
+          ReceiveState
+          {%- else -%}
+          TerminalState{%- endif -%}
+          .S{{ action.succ }};
+        {{ '}' }}
 
         const continuation = this.{{ action.label }}(...parsedMessage.payload);
         if (continuation instanceof Promise) {

--- a/codegen/generator/browser/templates/receive_component.tsx.j2
+++ b/codegen/generator/browser/templates/receive_component.tsx.j2
@@ -68,7 +68,7 @@ export default abstract class S{{ state }}<ComponentState = {}> extends React.Co
       case Labels.{{ action.label }}: {
         const thunk = () => {{ '{' }}
           {%- if action.succ.id == state.id %}
-          this.props.register(Roles.Peers.{{ state.first_role }}, this.handle.bind(this));
+          this.props.register(Roles.Peers.{{ state.role }}, this.handle.bind(this));
           {%- endif %}
           return {% if endpoint.efsm.is_send_state(action.succ) -%}
           SendState


### PR DESCRIPTION
associated issue: https://github.com/ansonmiu0214/TypeScript-Multiparty-Sessions/issues/53


this PR adds a line to the `thunk`, so that it will re-register for messages if the next state is also the current state